### PR TITLE
feat(quote): add params author i18n and icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,20 @@ Tags can be used in a `.md` file
 
 ### quote block tag
 
+Basic quote block:
+
+```liquid
+{% quote %}
+To quote or not to quote: That is the question.
+{% endquote %}
 ```
-{% quote {"author":"Britney Shakespears"} %}
+
+Quote block with params:
+
+```liquid
+{% quote { "author": "Bitnet Shakespeares", 
+           "icon": "svg/icon-quote_alt.liquid"} %}
+
 To quote or not to quote: That is the question.
 {% endquote %}
 ```

--- a/jekyll-plugin-platoniq-journal.gemspec
+++ b/jekyll-plugin-platoniq-journal.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-plugin-platoniq-journal"
-  spec.version       = "0.0.2"
+  spec.version       = "0.0.3"
   spec.authors       = ["Agustí B.R."]
   spec.email         = ["agusti@platoniq.net"]
 
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", "~> 4.2"
   spec.add_dependency "kramdown", "~> 2.3"
   spec.add_development_dependency "bundler", "> 1.0", "< 3.0"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.12"
 end

--- a/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# require "byebug"
+
 module Jekyll
   class QuoteBlockTag < Liquid::Block
     def initialize(tag_name, input, tokens)
@@ -7,29 +9,121 @@ module Jekyll
       @input = input
     end
 
-    def render(_context)
+    def render(context)
       text = super
+      @context = context
+      @site = site
 
-      jdata = if !@input.nil? && !@input.empty?
-                JSON.parse(@input)
-              else
-                JSON.parse({ :example => "123" })
-              end
+      @site.inclusions[icon_file_path] ||= locate_include_file(icon_file_path)
 
-      output = []
+      add_include_to_dependency(inclusion, context) if site.config["incremental"]
+      icon = nil
+      context.stack do
+        # context["include"] = parse_params(context) if @params
+        icon = inclusion.render(context)
+      end
 
-      output << %(<figure class="pj-quote">)
-      output << <<~QUOTE
+      output(text, icon).join
+    end
+
+    private
+
+    def jdata
+      @jdata ||= JSON.parse(@input) if !@input.nil? && !@input.empty?
+    end
+
+    def page
+      @page ||= @context.registers[:page].to_liquid
+    end
+
+    def page_locale
+      @page_locale ||= page["locale"] || "en"
+    end
+
+    def site
+      @site ||= @context.registers[:site]
+    end
+
+    def icon_file_path
+      # @icon_file_path ||=
+      if !jdata.nil? && !jdata["icon"].empty?
+        jdata["icon"]
+      else
+        "svg/icon-quote.liquid"
+      end
+    end
+
+    def quote(text, icon)
+      <<~QUOTE
         <blockquote>
+          #{icon}
+
           #{text}
         </blockquote>
-        <figcaption class="pj-quote--author">
-          by #{jdata["author"]}
-        </figcaption>
       QUOTE
-      output << %(</figure>)
+    end
 
-      output.join
+    def author
+      if !jdata.nil? && !jdata["author"].empty?
+        @author ||= <<~AUTHOR
+          <figcaption class="pj-quote--author">
+            #{t_authored_by} #{jdata["author"]}
+          </figcaption>
+        AUTHOR
+      end
+    end
+
+    def t_authored_by
+      @t_authored_by ||= site.data["i18n"][page_locale]["global"]["authored_by"]
+    end
+
+    def output(text, icon)
+      output = []
+      output << %(<figure class="pj-quote">)
+      output << quote(text, icon)
+      output << author if author
+      output << %(</figure>)
+      output
+    end
+
+    def inclusion
+      @inclusion ||= @site.inclusions[icon_file_path]
+    end
+
+    ## Methods below from Jekyll::Tags::OptimizedIncludeTag
+    # https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb
+    ##
+
+    def locate_include_file(file)
+      @site.includes_load_paths.each do |dir|
+        path = PathManager.join(dir, file)
+        return Inclusion.new(@site, dir, file) if valid_include_file?(path, dir)
+      end
+      raise IOError, could_not_locate_message(file, @site.includes_load_paths, @site.safe)
+    end
+
+    def valid_include_file?(path, dir)
+      File.file?(path) && !outside_scope?(path, dir)
+    end
+
+    def outside_scope?(path, dir)
+      @site.safe && !realpath_prefixed_with?(path, dir)
+    end
+
+    def realpath_prefixed_with?(path, dir)
+      File.realpath(path).start_with?(dir)
+    rescue StandardError
+      false
+    end
+
+    def could_not_locate_message(file, includes_dirs, safe)
+      message = "Could not locate the included file '#{file}' in any of "\
+        "#{includes_dirs}. Ensure it exists in one of those directories and"
+      message + if safe
+                  " is not a symlink as those are not allowed in safe mode."
+                else
+                  ", if it is a symlink, does not point outside your site source."
+                end
     end
   end
 end


### PR DESCRIPTION
##  Description

This PR improves the `quote_tag` block:
- adding an optional alternative **`icon`** param, by default the [`icon-quotes.liquid`](https://github.com/Platoniq/jekyll-theme-platoniq-journal/blob/main/_includes/svg/icon-quotes.liquid) svg is rendered (from the journal theme)
- optional **`author`** param, if present renders a translated string _by author_