### PR TITLE
feat(svg-inclusion): extract svg-inclusion methods into support module

### DIFF
--- a/jekyll-plugin-platoniq-journal.gemspec
+++ b/jekyll-plugin-platoniq-journal.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-plugin-platoniq-journal"
-  spec.version       = "0.0.4"
+  spec.version       = "0.0.6"
   spec.authors       = ["Agustí B.R."]
   spec.email         = ["agusti@platoniq.net"]
 

--- a/lib/jekyll-plugin-platoniq-journal.rb
+++ b/lib/jekyll-plugin-platoniq-journal.rb
@@ -2,6 +2,7 @@
 
 require "jekyll"
 require "kramdown"
+require "support/includes_file"
 require "jekyll-plugin-platoniq-journal/call_to_action_block_tag"
 require "jekyll-plugin-platoniq-journal/numbers_tag"
 require "jekyll-plugin-platoniq-journal/quote_tag"

--- a/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
@@ -4,6 +4,8 @@
 
 module Jekyll
   class QuoteBlockTag < Liquid::Block
+    include IncludesFile
+
     def initialize(tag_name, input, tokens)
       super
       @input = input
@@ -83,46 +85,6 @@ module Jekyll
       output << author if author
       output << %(</figure>)
       output
-    end
-
-    def inclusion
-      @inclusion ||= @site.inclusions[icon_file_path]
-    end
-
-    ## Methods below from Jekyll::Tags::OptimizedIncludeTag
-    # https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb
-    ##
-
-    def locate_include_file(file)
-      @site.includes_load_paths.each do |dir|
-        path = PathManager.join(dir, file)
-        return Inclusion.new(@site, dir, file) if valid_include_file?(path, dir)
-      end
-      raise IOError, could_not_locate_message(file, @site.includes_load_paths, @site.safe)
-    end
-
-    def valid_include_file?(path, dir)
-      File.file?(path) && !outside_scope?(path, dir)
-    end
-
-    def outside_scope?(path, dir)
-      @site.safe && !realpath_prefixed_with?(path, dir)
-    end
-
-    def realpath_prefixed_with?(path, dir)
-      File.realpath(path).start_with?(dir)
-    rescue StandardError
-      false
-    end
-
-    def could_not_locate_message(file, includes_dirs, safe)
-      message = "Could not locate the included file '#{file}' in any of "\
-        "#{includes_dirs}. Ensure it exists in one of those directories and"
-      message + if safe
-                  " is not a symlink as those are not allowed in safe mode."
-                else
-                  ", if it is a symlink, does not point outside your site source."
-                end
     end
   end
 end

--- a/lib/support/includes_file.rb
+++ b/lib/support/includes_file.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module IncludesFile
+    def inclusion
+      @inclusion ||= @site.inclusions[icon_file_path]
+    end
+
+    ## Methods below from Jekyll::Tags::OptimizedIncludeTag
+    # https://github.com/jekyll/jekyll/blob/master/lib/jekyll/tags/include.rb
+    ##
+
+    def locate_include_file(file)
+      site.includes_load_paths.each do |dir|
+        path = PathManager.join(dir, file)
+        return Inclusion.new(site, dir, file) if valid_include_file?(path, dir)
+      end
+      raise IOError, could_not_locate_message(file, @site.includes_load_paths, @site.safe)
+    end
+
+    def valid_include_file?(path, dir)
+      File.file?(path) && !outside_scope?(path, dir)
+    end
+
+    def outside_scope?(path, dir)
+      @site.safe && !realpath_prefixed_with?(path, dir)
+    end
+
+    def realpath_prefixed_with?(path, dir)
+      File.realpath(path).start_with?(dir)
+    rescue StandardError
+      false
+    end
+
+    def could_not_locate_message(file, includes_dirs, safe)
+      message = "Could not locate the included file '#{file}' in any of "\
+        "#{includes_dirs}. Ensure it exists in one of those directories and"
+      message + if safe
+                  " is not a symlink as those are not allowed in safe mode."
+                else
+                  ", if it is a symlink, does not point outside your site source."
+                end
+    end
+  end
+end


### PR DESCRIPTION
Adds `Jekyll::IncludesFile` module to encapsulate svg inclusion related methods