### PR TITLE
Fix(includes_file): Inclusion and PathManager classes inheritance

### DIFF
--- a/jekyll-plugin-platoniq-journal.gemspec
+++ b/jekyll-plugin-platoniq-journal.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-plugin-platoniq-journal"
-  spec.version       = "0.0.6"
+  spec.version       = "0.0.7"
   spec.authors       = ["Agustí B.R."]
   spec.email         = ["agusti@platoniq.net"]
 

--- a/lib/jekyll-plugin-platoniq-journal/includes_file.rb
+++ b/lib/jekyll-plugin-platoniq-journal/includes_file.rb
@@ -12,8 +12,8 @@ module JekyllPluginPlatoniqJournal
 
     def locate_include_file(file)
       site.includes_load_paths.each do |dir|
-        path = PathManager.join(dir, file)
-        return Inclusion.new(site, dir, file) if valid_include_file?(path, dir)
+        path = Jekyll::PathManager.join(dir, file)
+        return Jekyll::Inclusion.new(site, dir, file) if valid_include_file?(path, dir)
       end
       raise IOError, could_not_locate_message(file, @site.includes_load_paths, @site.safe)
     end


### PR DESCRIPTION
## Description

In #6 the includes methods where extracted to a module, due to this `Inclusion` and `PathManager`classes used lost the `Jekyll` inheritance and raised an error:

```
uninitialized constant JekyllPluginPlatoniqJournal::IncludesFile::Inclusion (NameError)
```

This pr fixes so this two classes inherit from `Jekyll` 