### PR TITLE
Refactor/cta template from theme

### DIFF
--- a/.github/workflows/jekyll-lint.yml
+++ b/.github/workflows/jekyll-lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Tags can be used in a `.md` file
 ### call to action block tag
 
 ```
-{% cta {"url":"https://platoniq.net", "label": "call to action button"} %}
+{% call_to_action {"url":"https://platoniq.net", "label": "call to action button"} %}
 # This is my CTA
 
 - one item
 - two item
-{% endcta %}
+{% endcall_to_action %}
 ```
 
 ### numbers tag

--- a/jekyll-plugin-platoniq-journal.gemspec
+++ b/jekyll-plugin-platoniq-journal.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-plugin-platoniq-journal"
-  spec.version       = "0.0.8"
+  spec.version       = "0.0.9"
   spec.authors       = ["Agustí B.R."]
   spec.email         = ["agusti@platoniq.net"]
 

--- a/lib/jekyll-plugin-platoniq-journal/base.rb
+++ b/lib/jekyll-plugin-platoniq-journal/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# require "byebug"
+
 module JekyllPluginPlatoniqJournal
   module Base
     def site

--- a/lib/jekyll-plugin-platoniq-journal/call_to_action_block_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/call_to_action_block_tag.rb
@@ -2,6 +2,9 @@
 
 module Jekyll
   class CallToActionBlockTag < Liquid::Block
+    include JekyllPluginPlatoniqJournal::Base
+    include JekyllPluginPlatoniqJournal::IncludesFile
+
     def initialize(tag_name, input, tokens)
       super
       @input = input
@@ -9,29 +12,30 @@ module Jekyll
 
     def render(context)
       text = super
+      @context = context
+      @site = site
 
-      jdata = if !@input.nil? && !@input.empty?
-                JSON.parse(@input)
-              else
-                JSON.parse({ :example => "123" })
-              end
+      @site.inclusions[include_file_path] ||= locate_include_file(include_file_path)
+      add_include_to_dependency(inclusion, context) if site.config["incremental"]
+      include_call_to_action = nil
+      context.stack do
+        context["include"] = jdata
+        include_call_to_action = inclusion.render(context)
+      end
 
-      output = []
+      include_call_to_action
+    end
 
-      output << %(<div class="px-4 py-5 my-5 text-center">)
-      output << Kramdown::Document.new(text).to_html if text
-      output << <<~CTA
-        <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-          <a href="#{jdata["url"]}" class="btn btn-primary btn-lg px-4 gap-3">
-            #{jdata["label"]}
-          </a>
-        </div>
-      CTA
-      output << %(</div>)
+    private
 
-      output.join
+    def jdata
+      @jdata ||= JSON.parse(@context[@input.strip]) if !@input.nil? && !@input.empty?
+    end
+
+    def include_file_path
+      @include_file_path ||= "plugins/call_to_action.liquid"
     end
   end
 end
 
-Liquid::Template.register_tag("cta", Jekyll::CallToActionBlockTag)
+Liquid::Template.register_tag("call_to_action", Jekyll::CallToActionBlockTag)

--- a/lib/jekyll-plugin-platoniq-journal/call_to_action_block_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/call_to_action_block_tag.rb
@@ -11,7 +11,7 @@ module Jekyll
     end
 
     def render(context)
-      text = super
+      super
       @context = context
       @site = site
 

--- a/lib/jekyll-plugin-platoniq-journal/includes_file.rb
+++ b/lib/jekyll-plugin-platoniq-journal/includes_file.rb
@@ -3,7 +3,7 @@
 module JekyllPluginPlatoniqJournal
   module IncludesFile
     def inclusion
-      @inclusion ||= @site.inclusions[icon_file_path]
+      @inclusion ||= @site.inclusions[include_file_path]
     end
 
     ## Methods below from Jekyll::Tags::OptimizedIncludeTag

--- a/lib/jekyll-plugin-platoniq-journal/links_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/links_tag.rb
@@ -14,7 +14,7 @@ module Jekyll
       @context = context
       @site = site
 
-      @site.inclusions[icon_file_path] ||= locate_include_file(icon_file_path)
+      @site.inclusions[include_file_path] ||= locate_include_file(include_file_path)
 
       add_include_to_dependency(inclusion, context) if site.config["incremental"]
 
@@ -32,8 +32,8 @@ module Jekyll
       @jdata ||= JSON.parse(@input) if !@input.nil? && !@input.empty?
     end
 
-    def icon_file_path
-      @icon_file_path ||= if !jdata.nil? && jdata["icon"]
+    def include_file_path
+      @include_file_path ||= if !jdata.nil? && jdata["icon"]
                             jdata["icon"]
                           else
                             "svg/icon-link.liquid"

--- a/lib/jekyll-plugin-platoniq-journal/links_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/links_tag.rb
@@ -34,10 +34,10 @@ module Jekyll
 
     def include_file_path
       @include_file_path ||= if !jdata.nil? && jdata["icon"]
-                            jdata["icon"]
-                          else
-                            "svg/icon-link.liquid"
-                          end
+                               jdata["icon"]
+                             else
+                               "svg/icon-link.liquid"
+                             end
     end
 
     def render_all

--- a/lib/jekyll-plugin-platoniq-journal/numbers_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/numbers_tag.rb
@@ -14,7 +14,7 @@ module Jekyll
       @context = context
       @site = site
 
-      @site.inclusions[icon_file_path] ||= locate_include_file(icon_file_path)
+      @site.inclusions[include_file_path] ||= locate_include_file(include_file_path)
 
       add_include_to_dependency(inclusion, context) if site.config["incremental"]
 
@@ -36,8 +36,8 @@ module Jekyll
                  end
     end
 
-    def icon_file_path
-      @icon_file_path ||= if !jdata.nil? && jdata["icon"]
+    def include_file_path
+      @include_file_path ||= if !jdata.nil? && jdata["icon"]
                             jdata["icon"]
                           else
                             "svg/icon-arrow_leftup.liquid"

--- a/lib/jekyll-plugin-platoniq-journal/numbers_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/numbers_tag.rb
@@ -38,10 +38,10 @@ module Jekyll
 
     def include_file_path
       @include_file_path ||= if !jdata.nil? && jdata["icon"]
-                            jdata["icon"]
-                          else
-                            "svg/icon-arrow_leftup.liquid"
-                          end
+                               jdata["icon"]
+                             else
+                               "svg/icon-arrow_leftup.liquid"
+                             end
     end
 
     def render_all

--- a/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
@@ -35,10 +35,10 @@ module Jekyll
 
     def include_file_path
       @include_file_path ||= if !jdata.nil? && jdata["icon"]
-                            jdata["icon"]
-                          else
-                            "svg/icon-quote.liquid"
-                          end
+                               jdata["icon"]
+                             else
+                               "svg/icon-quote.liquid"
+                             end
     end
 
     def quote(text, icon)

--- a/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
+++ b/lib/jekyll-plugin-platoniq-journal/quote_tag.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# require "byebug"
-
 module Jekyll
   class QuoteBlockTag < Liquid::Block
     include JekyllPluginPlatoniqJournal::Base
@@ -17,7 +15,7 @@ module Jekyll
       @context = context
       @site = site
 
-      @site.inclusions[icon_file_path] ||= locate_include_file(icon_file_path)
+      @site.inclusions[include_file_path] ||= locate_include_file(include_file_path)
 
       add_include_to_dependency(inclusion, context) if site.config["incremental"]
       icon = nil
@@ -35,8 +33,8 @@ module Jekyll
       @jdata ||= JSON.parse(@input) if !@input.nil? && !@input.empty?
     end
 
-    def icon_file_path
-      @icon_file_path ||= if !jdata.nil? && jdata["icon"]
+    def include_file_path
+      @include_file_path ||= if !jdata.nil? && jdata["icon"]
                             jdata["icon"]
                           else
                             "svg/icon-quote.liquid"


### PR DESCRIPTION
## Description

This PR refactors the `call_to_action` block, the plugin has no HTML and gets the template from the theme at `_includes/plugins/call_to_action`

renames the block to  `{% call_to_action %}`